### PR TITLE
fixes for undefined variables and multiple definitions

### DIFF
--- a/Snac/Makefile.def
+++ b/Snac/Makefile.def
@@ -35,9 +35,9 @@ endif
 
 def_sub += libSnac plugins src tests snac2vtk snac2dx snac2restart Python pyre 
 
-ifeq (true,$(shell if test -x $(DOXYGEN); then echo true; fi ))
-	def_sub += doc
-else
-	warn := $(shell echo Not entering doc directory as doxygen not found. 1>&2 )
-	warn := $(shell echo To generate doxgen docs, please set the DOXYGEN environment variable then re-run configure.sh. 1>&2 )
-endif
+#ifeq (true,$(shell if test -x $(DOXYGEN); then echo true; fi ))
+#	def_sub += doc
+#else
+#	warn := $(shell echo Not entering doc directory as doxygen not found. 1>&2 )
+#	warn := $(shell echo To generate doxgen docs, please set the DOXYGEN environment variable then re-run configure.sh. 1>&2 )
+#endif

--- a/Snac/libSnac/tests/testSnacContext-4-4-4.c
+++ b/Snac/libSnac/tests/testSnacContext-4-4-4.c
@@ -43,12 +43,12 @@
 
 #define TOL 1.0e-09
 
-int				numProcessors;
-int				procToWatch;
-int				rank;
-MPI_Comm			CommWorld;
-Dictionary*			dictionary;
-Snac_Context*			snacContext;
+extern int				numProcessors;
+extern int				procToWatch;
+extern int				rank;
+extern MPI_Comm			CommWorld;
+extern Dictionary*			dictionary;
+extern Snac_Context*			snacContext;
 
 int main( int argc, char* argv[] ) {
 

--- a/Snac/plugins/Makefile.def
+++ b/Snac/plugins/Makefile.def
@@ -32,4 +32,4 @@
 ##
 ##~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-def_sub = customCartesianMesh cylinder_quadrant cylindrical elastic exchanger heterogeneities hydroStaticIC temperature maxwell remesher_BI restarter restarter_old spherical plastic_BI plSeeds viscoplastic_BI vpSeeds winkler hillSlope tractionBC conditionFunctions dikeInjection
+def_sub = customCartesianMesh cylinder_quadrant cylindrical elastic exchanger heterogeneities hydroStaticIC temperature maxwell remesher_BI restarter restarter_old spherical plastic_BI plSeeds viscoplastic_BI vpSeeds winkler tractionBC conditionFunctions dikeInjection

--- a/Snac/plugins/cylindrical/Register.c
+++ b/Snac/plugins/cylindrical/Register.c
@@ -66,7 +66,8 @@ void* _SnacCylindrical_DefaultNew( Name name ) {
 }
 
 
-void _SnacCustomCartesian_Construct( void* component, Stg_ComponentFactory* cf, void* data ) {
+/* void _SnacCustomCartesian_Construct( void* component, Stg_ComponentFactory* cf, void* data ) { */
+void _SnacCylindrical_Construct( void* component, Stg_ComponentFactory* cf, void* data ) {
 	Snac_Context*	context;
 
 	/* Retrieve context. */

--- a/Snac/plugins/dikeInjection/makefile
+++ b/Snac/plugins/dikeInjection/makefile
@@ -45,7 +45,7 @@ SRCS = ${def_srcs}
 HDRS = ${def_hdrs}
 
 PROJ_LIBS = ${def_libs}
-EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain 
+EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain ${SNAC_LIBDIR}/SnacViscoPlasticmodule.so
 EXTERNAL_INCLUDES = -I${STGERMAIN_INCDIR}/StGermain -I${STGERMAIN_INCDIR} 
 
 packages = MPI XML MATH

--- a/Snac/plugins/hillSlope/makefile
+++ b/Snac/plugins/hillSlope/makefile
@@ -45,7 +45,7 @@ SRCS = ${def_srcs}
 HDRS = ${def_hdrs}
 
 PROJ_LIBS = ${def_libs}
-EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain 
+EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain ${SNAC_LIBDIR}/SnacPlasticmodule.so
 EXTERNAL_INCLUDES = -I${STGERMAIN_INCDIR}/StGermain -I${STGERMAIN_INCDIR} 
 
 packages = MPI XML MATH

--- a/Snac/plugins/hydroStaticIC/Register.c
+++ b/Snac/plugins/hydroStaticIC/Register.c
@@ -48,6 +48,10 @@ static char RMAX_STR[] = "rMax";
 static char MESH_STR[] = "mesh";
 static double MIN[] = { -45.0f, -45.0f, 0.5f };
 static double MAX[] = { 45.0f, 45.0f, 1.0f };
+/* First-time definition of these extern variables (Force.h) */
+/* The proper values are asgined in _SnacWinklerForce_Construct. */
+double Spherical_RMin = 0.0;
+double Spherical_RMax = 0.0;
 
 Index _SnacHydroStaticIC_Register( PluginsManager* pluginsMgr ) {
 	return PluginsManager_Submit( pluginsMgr,

--- a/Snac/plugins/hydroStaticIC/VariableConditions.h
+++ b/Snac/plugins/hydroStaticIC/VariableConditions.h
@@ -43,7 +43,7 @@
 
 void _SnacHydroStaticIC_IC( void* _context );
 void _SnacHydroStaticIC_IC_Spherical( void* _context );
-	double Spherical_RMin;
-	double Spherical_RMax;
+extern double Spherical_RMin;
+extern double Spherical_RMax;
 
 #endif /* __Snac_HydroStaticIC_VariableConditions_h__ */

--- a/Snac/plugins/maxwell/makefile
+++ b/Snac/plugins/maxwell/makefile
@@ -45,7 +45,7 @@ SRCS = ${def_srcs}
 HDRS = ${def_hdrs}
 
 PROJ_LIBS = ${def_libs}
-EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR} -lSnac -lStGermain 
+EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR} -lSnac -lStGermain ${SNAC_LIBDIR}/SnacTemperaturemodule.so
 EXTERNAL_INCLUDES = -I${STGERMAIN_INCDIR}/StGermain -I${STGERMAIN_INCDIR} 
 
 packages = MPI XML MATH

--- a/Snac/plugins/plSeeds/makefile
+++ b/Snac/plugins/plSeeds/makefile
@@ -45,7 +45,7 @@ SRCS = ${def_srcs}
 HDRS = ${def_hdrs}
 
 PROJ_LIBS = ${def_libs}
-EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain 
+EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain ${SNAC_LIBDIR}/SnacPlasticmodule.so
 EXTERNAL_INCLUDES = -I${STGERMAIN_INCDIR}/StGermain -I${STGERMAIN_INCDIR} 
 
 packages = MPI XML MATH

--- a/Snac/plugins/plastic_BI/Constitutive.c
+++ b/Snac/plugins/plastic_BI/Constitutive.c
@@ -131,11 +131,13 @@ void SnacPlastic_Constitutive( void* _context, Element_LocalIndex element_lI ) {
 				}
 			}
 
-			if( frictionAngle > 0.0f ) {
+			if( frictionAngle >= 0.0f ) {
 				tension_cutoff = material->ten_off;
-				if( frictionAngle > 0.0) {
-					tmp = cohesion / tan( frictionAngle * degrad);
-					if(tmp < tension_cutoff) tension_cutoff=tmp;
+				/* tension_cutoff is 0 by default. If not set by a user, it is set here.*/
+				if( frictionAngle > 0.0 && tension_cutoff == 0.0 ) {
+					tension_cutoff = cohesion / tan( frictionAngle * degrad);
+					/* tmp = cohesion / tan( frictionAngle * degrad);
+					if(tmp < tension_cutoff) tension_cutoff=tmp; */
 				}
 			}
 			else {

--- a/Snac/plugins/plastic_BI/makefile
+++ b/Snac/plugins/plastic_BI/makefile
@@ -45,7 +45,7 @@ SRCS = ${def_srcs}
 HDRS = ${def_hdrs}
 
 PROJ_LIBS = ${def_libs}
-EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain 
+EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain ${SNAC_LIBDIR}/SnacRemeshermodule.so
 EXTERNAL_INCLUDES = -I${STGERMAIN_INCDIR}/StGermain -I${STGERMAIN_INCDIR} 
 
 packages = MPI XML MATH

--- a/Snac/plugins/remesher_BI/Register.c
+++ b/Snac/plugins/remesher_BI/Register.c
@@ -48,8 +48,9 @@
 /* Textual name of this class */
 const Type SnacRemesher_Type = "SnacRemesher";
 
-ExtensionInfo_Index SnacRemesher_ContextHandle;
-ExtensionInfo_Index SnacRemesher_MeshHandle;
+/* Define these extern variables here and let them take proper values below. */
+ExtensionInfo_Index SnacRemesher_ContextHandle = 0;
+ExtensionInfo_Index SnacRemesher_MeshHandle = 0;
 
 const Name SnacRemesher_EP_InterpolateNode =	"SnacRemesher_EP_InterpolateNode";
 const Name SnacRemesher_EP_InterpolateElement =	"SnacRemesher_EP_InterpolateElement";

--- a/Snac/plugins/remesher_BI/RemeshElements.c
+++ b/Snac/plugins/remesher_BI/RemeshElements.c
@@ -334,7 +334,7 @@ void createBarycenterGrids( void* _context )
 	for( element_lI = 0; element_lI < mesh->elementLocalCount; element_lI++ ) {
 		unsigned			nEltNodes;
 		Node_DomainIndex*	eltNodes;
-        Element_GlobalIndex	gEltInd;
+        	Element_GlobalIndex	gEltInd;
 
 		/* Extract the element's node indices.  Note that there should always be eight of these. */
 		{
@@ -346,7 +346,7 @@ void createBarycenterGrids( void* _context )
 		
 		/* Convert global node indices to local. */
 		{
-			unsigned	eltNode_i;
+			unsigned	eltNode_i, elgI, elgJ, elgK;
 			
 			meshExt->newBarycenters[element_lI][0] = 0.0;
 			meshExt->newBarycenters[element_lI][1] = 0.0;
@@ -362,20 +362,26 @@ void createBarycenterGrids( void* _context )
 			/* 			meshExt->newBarycenters[element_lI][0],meshExt->newBarycenters[element_lI][1], */
 			/* 			meshExt->newBarycenters[element_lI][2]); */
 
-            /* Special treatment to test.
-               Since some boundary elements of the new mesh fail to find containing old element,
-               push the barycenters "inward" by a small amount so that these elements are forced
-               to be inside the old mesh. */
-            RegularMeshUtils_Element_1DTo3D( decomp, gEltInd, &elgI, &elgJ, &elgK ); /* Decompose gEltInd into ijk indexes. */
-            /* The factor 1.0e-3 is totally experimental.
-               To minimize error this treatment introduces into barycentric interpolation,
-               a minimum value would have to be found and used. */
-            if( elgI == 0 )        meshExt->newBarycenters[element_lI][0] += 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][0]);
-            if( elgI == nelgI-1 )  meshExt->newBarycenters[element_lI][0] -= 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][0]);
-            if( elgJ == 0 )        meshExt->newBarycenters[element_lI][1] += 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][1]);
-            if( elgJ == nelgJ-1 )  meshExt->newBarycenters[element_lI][1] -= 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][1]);
-            if( elgK == 0 )        meshExt->newBarycenters[element_lI][2] += 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][2]);
-            if( elgK == nelgK-1 )  meshExt->newBarycenters[element_lI][2] -= 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][2]);
+            		/* Special treatment to test.
+               		   Since some boundary elements of the new mesh fail to find containing old element,
+               		   push the barycenters "inward" by a small amount so that these elements are forced
+               		   to be inside the old mesh. */
+            		RegularMeshUtils_Element_1DTo3D( decomp, gEltInd, &elgI, &elgJ, &elgK ); /* Decompose gEltInd into ijk indexes. */
+            		/* The factor 1.0e-3 is totally experimental.
+            		   To minimize error this treatment introduces into barycentric interpolation,
+            		   a minimum value would have to be found and used. */
+            		if( elgI == 0 )
+				meshExt->newBarycenters[element_lI][0] += 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][0]);
+            		if( elgI == decomp->elementGlobal3DCounts[0]-1 )  
+				meshExt->newBarycenters[element_lI][0] -= 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][0]);
+            		if( elgJ == 0 )
+				meshExt->newBarycenters[element_lI][1] += 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][1]);
+            		if( elgJ == decomp->elementGlobal3DCounts[1]-1 )
+				meshExt->newBarycenters[element_lI][1] -= 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][1]);
+            		if( elgK == 0 )
+				meshExt->newBarycenters[element_lI][2] += 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][2]);
+            		if( elgK == decomp->elementGlobal3DCounts[2]-1 )
+				meshExt->newBarycenters[element_lI][2] -= 1.0e-3 * fabs(meshExt->newBarycenters[element_lI][2]);
 		}
 	}
 

--- a/Snac/plugins/viscoplastic/makefile
+++ b/Snac/plugins/viscoplastic/makefile
@@ -45,7 +45,7 @@ SRCS = ${def_srcs}
 HDRS = ${def_hdrs}
 
 PROJ_LIBS = ${def_libs}
-EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain
+EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain ${SNAC_LIBDIR}/SnacTemperaturemodule.so ${SNAC_LIBDIR}/SnacRemeshermodule.so
 EXTERNAL_INCLUDES = -I${STGERMAIN_INCDIR}/StGermain -I${STGERMAIN_INCDIR} 
 
 packages = MPI XML MATH

--- a/Snac/plugins/viscoplastic_BI/Constitutive.c
+++ b/Snac/plugins/viscoplastic_BI/Constitutive.c
@@ -279,11 +279,13 @@ void SnacViscoPlastic_Constitutive( void* _context, Element_LocalIndex element_l
 				}
 			}
 
-			if( frictionAngle > 0.0f ) {
+			if( frictionAngle >= 0.0f ) {
 				tension_cutoff = material->ten_off;
-				if( frictionAngle > 0.0) {
-					tmp = cohesion / tan( frictionAngle * degrad);
-					if(tmp < tension_cutoff) tension_cutoff=tmp;
+				/* tension_cutoff is 0 by default. If not set by a user, it is set here.*/
+				if( frictionAngle > 0.0 && tension_cutoff == 0.0 ) {
+					tension_cutoff = cohesion / tan( frictionAngle * degrad);
+					/* tmp = cohesion / tan( frictionAngle * degrad);
+					if(tmp < tension_cutoff) tension_cutoff=tmp; */
 				}
 			}
 			else {

--- a/Snac/plugins/vpSeeds/makefile
+++ b/Snac/plugins/vpSeeds/makefile
@@ -45,7 +45,7 @@ SRCS = ${def_srcs}
 HDRS = ${def_hdrs}
 
 PROJ_LIBS = ${def_libs}
-EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain 
+EXTERNAL_LIBS = -L${STGERMAIN_LIBDIR}  -lSnac -lStGermain ${SNAC_LIBDIR}/SnacViscoPlasticmodule.so
 EXTERNAL_INCLUDES = -I${STGERMAIN_INCDIR}/StGermain -I${STGERMAIN_INCDIR} 
 
 packages = MPI XML MATH

--- a/Snac/plugins/winkler/Force.h
+++ b/Snac/plugins/winkler/Force.h
@@ -57,7 +57,7 @@
 		Mass*				inertialMass,
 		Force*				force,
 		Force*				balance );
-	double Spherical_RMin;
-	double Spherical_RMax;
+	extern double Spherical_RMin;
+	extern double Spherical_RMax;
 
 #endif /* __Snac_WinklerForce_VariableConditions_h__ */

--- a/Snac/plugins/winkler/Register.c
+++ b/Snac/plugins/winkler/Register.c
@@ -50,6 +50,10 @@ static char RMAX_STR[] = "rMax";
 static char MESH_STR[] = "mesh";
 static double MIN[] = { -45.0f, -45.0f, 0.5f };
 static double MAX[] = { 45.0f, 45.0f, 1.0f };
+/* First-time definition of these extern variables (Force.h) */
+/* The proper values are asgined in _SnacWinklerForce_Construct. */
+double Spherical_RMin = 0.0;
+double Spherical_RMax = 0.0;
 
 Index _SnacWinklerForce_Register( PluginsManager* pluginsMgr ) {
 	return PluginsManager_Submit( pluginsMgr, 

--- a/StGermain/Base/Extensibility/src/PluginLoader.c
+++ b/StGermain/Base/Extensibility/src/PluginLoader.c
@@ -97,6 +97,7 @@ PluginLoader* PluginLoader_NewLocal( Name pluginName, Stg_ObjectList* directorie
 	stream =  Journal_Register( Info_Type, "PluginLoaders" );
 	debug =  Journal_Register( Debug_Type, "PluginLoaders" );
 	error =  Journal_Register( Error_Type, "PluginLoaders" );
+	(void)error; /* to suppress unused-but-set-variable warning. */
 
 	assert( pluginName );
 

--- a/StGermain/Base/Extensibility/src/PluginsManager.c
+++ b/StGermain/Base/Extensibility/src/PluginsManager.c
@@ -318,6 +318,7 @@ Bool PluginsManager_LoadPlugin( void* plugins, Name pluginName, void* _context )
 	stream =  Journal_Register( Info_Type, "Plugins" );
 	debug =  Journal_Register( Debug_Type, "Plugins" );
 	error =  Journal_Register( Error_Type, "Plugins" );
+	(void)error; /* To suppress unused-but-set-variable warning. */
 
 	if ( Stg_ObjectList_Get( self->plugins, pluginName ) != NULL ) {
 		Journal_Printf( debug, "Plugin %s already loaded\n", pluginName );


### PR DESCRIPTION
5831925b7954919987d4038a0e41a3afb270419f : With the proposed fixes, snac can be built with a combination of a recent gcc and a flavor of MPI. It will also streamline the process of building a Docker image.

c9a7d8b49894765c7bd892c101c90ee966941e95: Fixed many run-time errors due to undefined symbols in plugins mostly by linking the required plugins together. Both cookbook examples run through with the built Snac executable. Tested on `Ubuntu 22.04` with `gcc 11.4`, `openmpi 4.1.2`.


